### PR TITLE
anno-mturk-template.sh bug fix

### DIFF
--- a/webapp/make-mturk-template.sh
+++ b/webapp/make-mturk-template.sh
@@ -15,10 +15,10 @@ echo "" >> anno-app-mturk.html
 echo "<script type=\"text/javascript\">" >> anno-app-mturk.html
 cat build/static/js/main.*.js >> anno-app-mturk.html
 echo "</script>" >> anno-app-mturk.html
-echo "" >> anno-app-turkle.html
+echo "" >> anno-app-mturk.html
 
-echo "<script type=\"text/javascript\">" >> anno-app-turkle.html
-cat build/static/js/runtime-main.*.js >> anno-app-turkle.html
-echo "</script>" >> anno-app-turkle.html
+echo "<script type=\"text/javascript\">" >> anno-app-mturk.html
+cat build/static/js/runtime-main.*.js >> anno-app-mturk.html
+echo "</script>" >> anno-app-mturk.html
 
 echo "DONE"


### PR DESCRIPTION
This PR is primarily targeted to fix the generation of `anno-mturk-template.sh`. Some of the scripts were copied to the wrong location i.e. `anno-app-turkle.html` instead of `anno-app-mturk.html` that was broke the injection of `.css` and `.js` files. This fix would allow users to simply run the command and upload the template on Mturk to run a study as intended by the authors of the repository.